### PR TITLE
Integrate rangy highlights into colighter nostr model

### DIFF
--- a/apps/extension/src/utils/Highlighting.ts
+++ b/apps/extension/src/utils/Highlighting.ts
@@ -1,10 +1,8 @@
-import { ActionResponse, ISerializedRange } from '../types';
+import { ActionResponse } from '../types';
 
 import rangy from 'rangy';
 import 'rangy/lib/rangy-classapplier';
 import 'rangy/lib/rangy-highlighter';
-
-// const HIGHLIGHT_KEY: string = 'NPKryv4iXxihMRg2gxRkTfFhwXmNmX9F';
 
 /** Gets the highlighter instance */
 export const getHighlighter = () => {
@@ -18,32 +16,6 @@ export const getHighlighter = () => {
   highlighter.addClassApplier(rangy.createClassApplier('highlight'));
 
   return highlighter;
-};
-
-/* Get selection info from window selection object */
-export const getSelectionInfo = async (): Promise<{
-  selection: Selection;
-  range: RangyRange;
-  text: string;
-}> => {
-  const selection = rangy.getSelection();
-  let range: RangyRange | null = null;
-  let text = '';
-
-  if (selection) {
-    range = selection.getRangeAt(0);
-    text = range.toString();
-  }
-
-  if (selection === null || range === null) {
-    throw new Error('Failed to get selection');
-  }
-
-  if (!text) {
-    throw new Error('No text selected');
-  }
-
-  return Promise.resolve({ selection, range, text });
 };
 
 export const createSelectionAtRange = (range: RangyRange): RangySelection => {
@@ -68,7 +40,6 @@ export const highlightCurrentSelection = async (
   const selectedText = rangy.getSelection();
   const serializedRange = highlighter.serialize();
 
-  // highlighter.deserialize(serializedRange);
   rangy.getSelection().removeAllRanges();
 
   return Promise.resolve({ selectedText, serializedRange });
@@ -78,97 +49,6 @@ export const highlightCurrentSelection = async (
 export const removeCurrentSelectionHighlight = async (
   highlighter: Highlighter
 ): Promise<ActionResponse> => {
-  const { selection, range, text } = await getSelectionInfo();
-
-  if (selection === null || range === null) {
-    return {
-      success: false,
-      error: 'Failed to get selection',
-    } as ActionResponse;
-  }
-
-  if (!text) {
-    return { success: false, error: 'No text selected' } as ActionResponse;
-  }
-
   highlighter.unhighlightSelection();
   return { success: true };
-};
-
-export const serializeRange = (range: Range): ISerializedRange => {
-  const startContainer = range.startContainer;
-  const endContainer = range.endContainer;
-
-  const startOffset = range.startOffset;
-  const endOffset = range.endOffset;
-
-  const startPath = getNodePath(startContainer);
-  const endPath = getNodePath(endContainer);
-
-  return {
-    startPath,
-    endPath,
-    startOffset,
-    endOffset,
-  };
-};
-
-const getNodePath = (node: Node): number[] => {
-  const path: number[] = [];
-
-  while (node !== document.body) {
-    const parent = node.parentNode;
-    if (!parent) {
-      throw new Error('Node not found in document body');
-    }
-    const index = Array.prototype.indexOf.call(parent.childNodes, node);
-    path.push(index);
-    node = parent;
-  }
-
-  return path.reverse();
-};
-
-// TODO: Redefine range serialization to work with all cases of highlighting the DOM
-export const hackyDeserializeRange = (
-  { startPath }: ISerializedRange,
-  text: string
-): Range => {
-  const range = document.createRange();
-
-  const ancestor = getNodeFromPath(startPath);
-  const ancestorText = ancestor.textContent || '';
-  const startOffset = ancestorText.indexOf(text);
-
-  if (startOffset !== -1 && ancestor.firstChild) {
-    const endOffset = startOffset + text.length;
-    range.setStart(ancestor.firstChild, startOffset);
-    range.setEnd(ancestor.firstChild, endOffset);
-  }
-
-  return range;
-};
-
-const getNodeFromPath = (path: number[]): Node => {
-  let node: Node = document.body;
-
-  for (const index of path) {
-    node = node.childNodes[index];
-  }
-
-  if (!node) {
-    throw new Error('Node not found in document body');
-  }
-
-  return node;
-};
-
-export const sha256Hash = async (message: string): Promise<string> => {
-  const encoder = new TextEncoder();
-  const hashArray = Array.from(
-    new Uint8Array(
-      await crypto.subtle.digest('SHA-256', encoder.encode(message))
-    )
-  );
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 };


### PR DESCRIPTION
**Notes:**
 - Looks like rangy model references al highlights on the page as the highlight. For example, the first highlight may have range `type:textContent|2$1750$3$highlight$`, the fifth has `type:textContent|2$1750$3$highlight$|3099$3577$4$highlight$|4352$4399$8$highlight$|4433$5063$7$highlight$|5135$5490$9$highlight$`. We'd need a more efficient representation, where each each highlight to contain just it's range rep
- There's a bug in parsing plain highlight text from type  `WrappedSelection` . `toString()` always returns an empty, thus highlights are empty
- PR does not implement local storage persistence of loaded highlights

![image](https://github.com/BalogunofAfrica/coolighter/assets/11217077/4772c6d6-b413-49d7-a3a8-33bc1b95de51)
